### PR TITLE
Add idle logout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { HashRouter, Route, Routes } from "react-router-dom";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { LandingPage } from "./pages/LandingPage/LandingPage";
 import { AuthProvider } from "./context/authContext";
@@ -6,6 +6,8 @@ import { HomePage } from "./pages/HomePage/HomePage";
 import { AdminRoute } from "./pages/AdminPage/AdminRoute";
 import { AdminPage } from "./pages/AdminPage/AdminPage";
 import { Toaster } from "sonner";
+import { IdleTimerProvider } from "./contexts/IdleTimerContext";
+import { IdleWarningModal } from "./components/common/IdleWarningModal";
 const queryClient = new QueryClient();
 
 function App() {
@@ -13,20 +15,23 @@ function App() {
         <QueryClientProvider client={queryClient}>
             <AuthProvider>
                 <Toaster />
-                <HashRouter>
-                    <Routes>
-                        <Route path="/" element={<LandingPage />} />
-                        <Route path="/Home" element={<HomePage />} />
-                        <Route
-                            path="/Admin"
-                            element={
-                                <AdminRoute>
-                                    <AdminPage />
-                                </AdminRoute>
-                            }
-                        />
-                    </Routes>
-                </HashRouter>
+                <BrowserRouter>
+                    <IdleTimerProvider>
+                        <Routes>
+                            <Route path="/" element={<LandingPage />} />
+                            <Route path="/Home" element={<HomePage />} />
+                            <Route
+                                path="/Admin"
+                                element={
+                                    <AdminRoute>
+                                        <AdminPage />
+                                    </AdminRoute>
+                                }
+                            />
+                        </Routes>
+                        <IdleWarningModal />
+                    </IdleTimerProvider>
+                </BrowserRouter>
             </AuthProvider>
         </QueryClientProvider>
     );

--- a/src/api/api-base.ts
+++ b/src/api/api-base.ts
@@ -40,7 +40,12 @@ api.interceptors.response.use(
                 const response = await axios.post<{ access_token: string }>(
                     `${api.defaults.baseURL}/auth/refreshToken`,
                     {},
-                    { withCredentials: true }
+                    {
+                        withCredentials: true,
+                        headers: {
+                            "Content-Type": "application/json",
+                        },
+                    }
                 );
 
                 const newAccessToken = response.data.access_token;

--- a/src/components/common/IdleWarningModal.tsx
+++ b/src/components/common/IdleWarningModal.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { useIdleTimer } from "@/contexts/IdleTimerContext";
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Timer } from "lucide-react";
+
+export const IdleWarningModal = () => {
+    const { showWarning, remainingTime, resetTimer } = useIdleTimer();
+
+    return (
+        <Dialog
+            open={showWarning}
+            onOpenChange={(isOpen) => {
+                if (!isOpen) {
+                    resetTimer();
+                }
+            }}
+        >
+            <DialogContent className="max-w-[90vw] w-[90vw] p-6">
+                <DialogHeader>
+                    <DialogTitle className="text-2xl">
+                        Session Timeout Warning
+                    </DialogTitle>
+                </DialogHeader>
+
+                <div className="flex flex-col items-center justify-center py-8 min-h-[300px]">
+                    <div className="text-center">
+                        <div className="animate-pulse text-yellow-400 mb-4">
+                            <Timer size={72} className="mx-auto" />
+                        </div>
+                        <h3 className="text-2xl font-medium mb-4">
+                            Your session is about to expire
+                        </h3>
+                        <p className="text-gray-400 mb-6 text-lg">
+                            Due to inactivity, your session will expire in{" "}
+                            {remainingTime} seconds.
+                        </p>
+                        <Button
+                            onClick={resetTimer}
+                            className="h-14 px-6 bg-green-500 hover:bg-green-600 text-lg"
+                        >
+                            Continue Session
+                        </Button>
+                    </div>
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+};

--- a/src/components/features/Reservations/ReservationSidebar.tsx
+++ b/src/components/features/Reservations/ReservationSidebar.tsx
@@ -87,7 +87,7 @@ export default function ReservationSidebar({
                 >
                     <Button
                         variant="outline"
-                        className="w-full flex items-center justify-center gap-2 text-gray-300 hover:text-white hover:bg-gray-700"
+                        className="w-full h-14 px-6 flex items-center justify-center gap-2 text-gray-300 hover:text-white hover:bg-gray-700"
                     >
                         <History className="w-4 h-4" />
                         Show History

--- a/src/contexts/IdleTimerContext.tsx
+++ b/src/contexts/IdleTimerContext.tsx
@@ -1,0 +1,111 @@
+import React, {
+    createContext,
+    useContext,
+    useEffect,
+    useState,
+    useCallback,
+} from "react";
+import debounce from "lodash/debounce";
+import { useAuth } from "@/context/authContext";
+import { useNavigate } from "react-router-dom";
+
+interface IdleTimerContextType {
+    showWarning: boolean;
+    remainingTime: number;
+    resetTimer: () => void;
+}
+
+const IdleTimerContext = createContext<IdleTimerContextType | undefined>(
+    undefined
+);
+
+export const IdleTimerProvider = ({
+    children,
+}: {
+    children: React.ReactNode;
+}) => {
+    const [remainingTime, setRemainingTime] = useState(60);
+    const [showWarning, setShowWarning] = useState(false);
+    const [timer, setTimer] = useState<NodeJS.Timeout | null>(null);
+    const { logout } = useAuth();
+    const nav = useNavigate();
+
+    const handleLogout = useCallback(async () => {
+        setShowWarning(false);
+        await logout();
+        nav("/");
+    }, [logout, nav]);
+
+    const resetTimer = useCallback(() => {
+        setRemainingTime(60);
+        setShowWarning(false);
+    }, []);
+
+    const debouncedResetTimer = debounce(resetTimer, 200);
+
+    useEffect(() => {
+        const handleActivity = () => {
+            debouncedResetTimer();
+        };
+
+        window.addEventListener("mousemove", handleActivity);
+        window.addEventListener("keydown", handleActivity);
+        window.addEventListener("click", handleActivity);
+        window.addEventListener("scroll", handleActivity);
+        window.addEventListener("touchstart", handleActivity);
+
+        return () => {
+            window.removeEventListener("mousemove", handleActivity);
+            window.removeEventListener("keydown", handleActivity);
+            window.removeEventListener("click", handleActivity);
+            window.removeEventListener("scroll", handleActivity);
+            window.removeEventListener("touchstart", handleActivity);
+            debouncedResetTimer.cancel();
+        };
+    }, [debouncedResetTimer]);
+
+    useEffect(() => {
+        if (timer) {
+            clearInterval(timer);
+        }
+
+        const newTimer = setInterval(() => {
+            setRemainingTime((prev) => {
+                if (prev <= 0) {
+                    handleLogout();
+                    return 0;
+                }
+                if (prev === 30) {
+                    setShowWarning(true);
+                }
+                return prev - 1;
+            });
+        }, 1000);
+
+        setTimer(newTimer);
+
+        return () => {
+            if (newTimer) {
+                clearInterval(newTimer);
+            }
+        };
+    }, [handleLogout]);
+
+    return (
+        <IdleTimerContext.Provider
+            value={{ showWarning, remainingTime, resetTimer }}
+        >
+            {children}
+        </IdleTimerContext.Provider>
+    );
+};
+
+export const useIdleTimer = () => {
+    const context = useContext(IdleTimerContext);
+    if (context === undefined) {
+        throw new Error(
+            "useIdleTimer must be used within an IdleTimerProvider"
+        );
+    }
+    return context;
+};


### PR DESCRIPTION
- Adds context that keeps track of the idle time on the app. Starts at 60 and counts down. Once at 30, a modal will pop up saying that the user will be automatically logged out after 30 seconds. If the timer hits 0, the user is logged out and sent back to the landing screen.

- Also added fix for refresh token endpoint